### PR TITLE
Throw error when frontline deploy fails

### DIFF
--- a/tasks/deploy-frontline.js
+++ b/tasks/deploy-frontline.js
@@ -89,6 +89,8 @@ async function deployFrontline(config, branch, rev) {
       gutil.colors.red(`Failed to deploy ${branch}(${rev})`),
       argv.debug ? e : 'Use --debug to view errors.',
     );
+
+    throw(e);
   }
 }
 


### PR DESCRIPTION
If deployment fails for a frontline deployed app, the build continues instead of failing. Rethrowing the error after the debug code is printed should do the trick.