### PR TITLE
Add dynamic config argument for deploys

### DIFF
--- a/tasks/deploy-frontline.js
+++ b/tasks/deploy-frontline.js
@@ -26,6 +26,11 @@ const argv = require('yargs')
       demandOption: false,
       type: 'string',
     },
+    config: {
+      describe: 'Specify a config file for the frontline deploy',
+      demandOption: false,
+      type: 'string',
+    },
   })
   .help().argv;
 

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -40,11 +40,16 @@ const argv = require('yargs')
       demandOption: false,
       type: 'boolean',
     },
+    config: {
+      describe: 'Specify a config file for the frontline deploy',
+      demandOption: false,
+      type: 'string',
+    },
   })
   .help().argv;
 
 const DEFAULT_ABBREV_LENGTH = 7;
-const CONFIG_FILENAME = 'deploy-config.js';
+const CONFIG_FILENAME = argv.config || 'deploy-config.js';
 const CONFIG_PATHS = [
   path.join(process.cwd(), CONFIG_FILENAME),
   path.join(__dirname, '..', CONFIG_FILENAME),


### PR DESCRIPTION
@patrickkim @trevornelson @danielnovograd CR please

For `life-web`, we are looking to deploy statically rendered React components as separate html documents to Frontline. In order to do this, we need to deploy separate `indexPath` files to Frontline.

This PR adds the ability to designate a `config` file for a frontline deploy command. The idea here is that for different static components, we can run different `deploy-frontline` scripts with specific config files so we can cache multiple html files to serve.